### PR TITLE
chore: bump docker, tabitha, stringer

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -15,7 +15,6 @@ exclude:
   - '^(?i)help\b'
   - '^(?i)doc\b'
   - '^(?i)docs\b'
-  - '^(?i)refactor\b'
   - '^(?i)test\b'
   - '^(?i)trying\b'
   - '^(?i)workflow\b'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod download
-    - go install golang.org/x/tools/cmd/stringer@v0.1.5
+    - go install golang.org/x/tools/cmd/stringer@v0.5.0
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/dlclark/regexp2 v1.4.0
 	github.com/fatih/color v1.13.0
-	github.com/jimschubert/tabitha v0.1.0
+	github.com/jimschubert/tabitha v0.2.0
 	github.com/moby/buildkit v0.8.3
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.2.1
@@ -18,7 +18,7 @@ require (
 require (
 	github.com/containerd/typeurl v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible // indirect
+	github.com/docker/docker v20.10.22+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
@@ -26,6 +26,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jimschubert/stripansi v0.0.1 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,9 @@ github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r
 github.com/docker/docker v1.4.2-0.20180531152204-71cd53e4a197/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible h1:J2OhsbfqoBRRT048iD/tqXBvEQWQATQ8vew6LqQmDSU=
 github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.22+incompatible h1:6jX4yB+NtcbldT90k7vBSaWJDB3i+zkVJT9BEK8kQkk=
+github.com/docker/docker v20.10.22+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
@@ -554,8 +555,10 @@ github.com/ishidawataru/sctp v0.0.0-20191218070446-00ab2ac2db07/go.mod h1:co9pwD
 github.com/jaguilar/vt100 v0.0.0-20150826170717-2703a27b14ea/go.mod h1:QMdK4dGB3YhEW2BmA1wgGpPYI3HZy/5gD705PXKUVSg=
 github.com/jarcoal/httpmock v1.0.5/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jimschubert/tabitha v0.1.0 h1:fxk6CxFl84hGe+IxLRMMlyjjDk2L5EKT0lNWDFXOohM=
-github.com/jimschubert/tabitha v0.1.0/go.mod h1:EM7/Mbl4OCZNmuEPAjTRHIKOvPbrZkrcXl4EuC3fTrc=
+github.com/jimschubert/stripansi v0.0.1 h1:JX8XM3IvFluns11AlEjs3gOpVp7lXDECm4sQnLiSjAo=
+github.com/jimschubert/stripansi v0.0.1/go.mod h1:DRA5fSMCNyT+8+Uj4lhggGvKliUAcdrRd/DA4ODiS54=
+github.com/jimschubert/tabitha v0.2.0 h1:S0Fd7G3H4HvQh8Mkccvyp4Qr9aQpMWwjRUD3dkqk1v4=
+github.com/jimschubert/tabitha v0.2.0/go.mod h1:0df4px5HAOlK5MD+JdHPvsCsaUvgwMLPiueIro8edfk=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=


### PR DESCRIPTION
* github.com/docker/docker v20.10.22+incompatible
* github.com/jimschubert/tabitha v0.2.0
* golang.org/x/tools/cmd/stringer v0.5.0