### PR TITLE
Correct .goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,6 @@ builds:
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format: tar.gz
-    rlcp: true
     format_overrides:
       - goos: windows
         format: zip
@@ -79,7 +78,7 @@ dockers:
       - "--platform=linux/amd64"
 
 brews:
-  - tap:
+  - repository:
       owner: jimschubert
       name: homebrew-tap
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
https://github.com/jimschubert/docked/actions/runs/8366898238/job/22908125683

```
/opt/hostedtoolcache/goreleaser-action/1.24.0/x64/goreleaser check
  • checking                                 path=
  • DEPRECATED: archives.rlcp should not be used anymore, check https://goreleaser.com/deprecations#archivesrlcp for more info
  • DEPRECATED: brews.tap should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.24.0/x64/goreleaser' failed with exit code 2
```

https://goreleaser.com/deprecations#archivesrlcp
https://goreleaser.com/deprecations#brewstap